### PR TITLE
Add export --format bash-ifnotset | bash-ifempty options

### DIFF
--- a/cli/export.go
+++ b/cli/export.go
@@ -20,7 +20,6 @@ A number of formats are available:
   * dotenv:        SECRET="password"
   * json:          { "secret": "password" }
   * yaml:          secret: password
-  * bash-export:   export SECRET='password'
   * bash-ifnotset: : ${SECRET='password'}
   * bash-ifempty:  : ${SECRET:='password'}
   
@@ -48,7 +47,7 @@ func exportCmd() *cobra.Command {
 	)
 
 	cmd.Flags().StringVar(&storePath, "path", storePath, "path of the secrets file")
-	cmd.Flags().StringVar(&format, "format", format, "format of the generated output (bash|dotenv|json|yaml|bash-export|bash-ifnotset|bash-ifempty)")
+	cmd.Flags().StringVar(&format, "format", format, "format of the generated output (bash|dotenv|json|yaml|bash-ifnotset|bash-ifempty)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 

--- a/cli/export.go
+++ b/cli/export.go
@@ -45,7 +45,7 @@ func exportCmd() *cobra.Command {
 	)
 
 	cmd.Flags().StringVar(&storePath, "path", storePath, "path of the secrets file")
-	cmd.Flags().StringVar(&format, "format", format, "format of the generated output (bash|bash-export|dotenv|json|yaml)")
+	cmd.Flags().StringVar(&format, "format", format, "format of the generated output (bash|dotenv|json|yaml|bash-export|bash-ifnotset|bash-ifempty)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 

--- a/cli/export.go
+++ b/cli/export.go
@@ -17,6 +17,7 @@ Each secret in the file will be decrypted and output to standard out.
 A number of formats are available:
 
   * bash:   SECRET='password'
+  * bash-export:   export SECRET='password'
   * dotenv: SECRET="password"
   * json:   { "secret": "password" }
   * yaml:   secret: password
@@ -44,7 +45,7 @@ func exportCmd() *cobra.Command {
 	)
 
 	cmd.Flags().StringVar(&storePath, "path", storePath, "path of the secrets file")
-	cmd.Flags().StringVar(&format, "format", format, "format of the generated output (bash|dotenv|json|yaml)")
+	cmd.Flags().StringVar(&format, "format", format, "format of the generated output (bash|bash-export|dotenv|json|yaml)")
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 

--- a/cli/export.go
+++ b/cli/export.go
@@ -16,11 +16,14 @@ export: Export a secrets file in it's decrypted form.
 Each secret in the file will be decrypted and output to standard out.
 A number of formats are available:
 
-  * bash:   SECRET='password'
+  * bash:          SECRET='password'
+  * dotenv:        SECRET="password"
+  * json:          { "secret": "password" }
+  * yaml:          secret: password
   * bash-export:   export SECRET='password'
-  * dotenv: SECRET="password"
-  * json:   { "secret": "password" }
-  * yaml:   secret: password
+  * bash-ifnotset: : ${SECRET='password'}
+  * bash-ifempty:  : ${SECRET:='password'}
+  
 
 Please be careful when exporting your secrets, do not save them to disk!
 `

--- a/formatter/bash.go
+++ b/formatter/bash.go
@@ -55,3 +55,59 @@ func BashExport(w io.Writer, creds <-chan Item) error {
 	return nil
 
 }
+
+// BashIfNotSet implements the Formatter interface.
+//
+// It outputs the decrypted secrets in the form:
+//
+//   : ${MY_SECRET='my value'}
+//   : ${ANOTHER_ONE='string with ''quotes'''}
+//
+// The secret names are capitalized and the no processing is done to the string
+// except replacing all `'` with `''`.
+//
+// This will set the environment variable
+// only if it has not been previously set.
+func BashIfNotSet(w io.Writer, creds <-chan Item) error {
+
+	for item := range creds {
+		key := strings.ToUpper(item.Name)
+		value := item.Plaintext
+		value = strings.Replace(value, "'", "''", -1)
+		_, err := fmt.Fprintf(w, ": ${%s='%s'}\n", key, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+// BashIfEmpty implements the Formatter interface.
+//
+// It outputs the decrypted secrets in the form:
+//
+//   : ${MY_SECRET:='my value'}
+//   : ${ANOTHER_ONE:='string with ''quotes'''}
+//
+// The secret names are capitalized and the no processing is done to the string
+// except replacing all `'` with `''`.
+//
+// This will set the environment variable
+// only if it has not been previously set or if it is an empty string.
+func BashIfEmpty(w io.Writer, creds <-chan Item) error {
+
+	for item := range creds {
+		key := strings.ToUpper(item.Name)
+		value := item.Plaintext
+		value = strings.Replace(value, "'", "''", -1)
+		_, err := fmt.Fprintf(w, ": ${%s:='%s'}\n", key, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}

--- a/formatter/bash.go
+++ b/formatter/bash.go
@@ -31,31 +31,6 @@ func Bash(w io.Writer, creds <-chan Item) error {
 
 }
 
-// BashExport implements the Formatter interface.
-//
-// It outputs the decrypted secrets in the form:
-//
-//   export MY_SECRET='my value'
-//   export ANOTHER_ONE='string with ''quotes'''
-//
-// The secret names are capitalized and the no processing is done to the string
-// except replacing all `'` with `''`.
-func BashExport(w io.Writer, creds <-chan Item) error {
-
-	for item := range creds {
-		key := strings.ToUpper(item.Name)
-		value := item.Plaintext
-		value = strings.Replace(value, "'", "''", -1)
-		_, err := fmt.Fprintf(w, "export %s='%s'\n", key, value)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-
-}
-
 // BashIfNotSet implements the Formatter interface.
 //
 // It outputs the decrypted secrets in the form:

--- a/formatter/bash.go
+++ b/formatter/bash.go
@@ -30,3 +30,28 @@ func Bash(w io.Writer, creds <-chan Item) error {
 	return nil
 
 }
+
+// BashExport implements the Formatter interface.
+//
+// It outputs the decrypted secrets in the form:
+//
+//   export MY_SECRET='my value'
+//   export ANOTHER_ONE='string with ''quotes'''
+//
+// The secret names are capitalized and the no processing is done to the string
+// except replacing all `'` with `''`.
+func BashExport(w io.Writer, creds <-chan Item) error {
+
+	for item := range creds {
+		key := strings.ToUpper(item.Name)
+		value := item.Plaintext
+		value = strings.Replace(value, "'", "''", -1)
+		_, err := fmt.Fprintf(w, "export %s='%s'\n", key, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}

--- a/formatter/bash_test.go
+++ b/formatter/bash_test.go
@@ -9,3 +9,11 @@ func TestBash(t *testing.T) {
 func TestBashExport(t *testing.T) {
 	testFormatter(t, BashExport, "./testdata/bash-export")
 }
+
+func TestBashIfNotSet(t *testing.T) {
+	testFormatter(t, BashIfNotSet, "./testdata/bash-ifnotset")
+}
+
+func TestBashIfEmpty(t *testing.T) {
+	testFormatter(t, BashIfEmpty, "./testdata/bash-ifempty")
+}

--- a/formatter/bash_test.go
+++ b/formatter/bash_test.go
@@ -6,10 +6,6 @@ func TestBash(t *testing.T) {
 	testFormatter(t, Bash, "./testdata/bash")
 }
 
-func TestBashExport(t *testing.T) {
-	testFormatter(t, BashExport, "./testdata/bash-export")
-}
-
 func TestBashIfNotSet(t *testing.T) {
 	testFormatter(t, BashIfNotSet, "./testdata/bash-ifnotset")
 }

--- a/formatter/bash_test.go
+++ b/formatter/bash_test.go
@@ -5,3 +5,7 @@ import "testing"
 func TestBash(t *testing.T) {
 	testFormatter(t, Bash, "./testdata/bash")
 }
+
+func TestBashExport(t *testing.T) {
+	testFormatter(t, BashExport, "./testdata/bash-export")
+}

--- a/formatter/testdata/bash-export
+++ b/formatter/testdata/bash-export
@@ -1,0 +1,5 @@
+export MY_SECRET='my value'
+export ANOTHER_ONE='string with "double" and ''single'' quotes'
+export FOOBAR='string
+with
+newlines'

--- a/formatter/testdata/bash-export
+++ b/formatter/testdata/bash-export
@@ -1,5 +1,0 @@
-export MY_SECRET='my value'
-export ANOTHER_ONE='string with "double" and ''single'' quotes'
-export FOOBAR='string
-with
-newlines'

--- a/formatter/testdata/bash-ifempty
+++ b/formatter/testdata/bash-ifempty
@@ -1,0 +1,5 @@
+: ${MY_SECRET:='my value'}
+: ${ANOTHER_ONE:='string with "double" and ''single'' quotes'}
+: ${FOOBAR:='string
+with
+newlines'}

--- a/formatter/testdata/bash-ifnotset
+++ b/formatter/testdata/bash-ifnotset
@@ -1,0 +1,5 @@
+: ${MY_SECRET='my value'}
+: ${ANOTHER_ONE='string with "double" and ''single'' quotes'}
+: ${FOOBAR='string
+with
+newlines'}

--- a/utils/validators.go
+++ b/utils/validators.go
@@ -109,8 +109,6 @@ func ValidFormatter(format string) (formatter.Formatter, error) {
 	switch format {
 	case "bash":
 		ret = formatter.Bash
-	case "bash-export":
-		ret = formatter.BashExport
 	case "bash-ifnotset":
 		ret = formatter.BashIfNotSet
 	case "bash-ifempty":

--- a/utils/validators.go
+++ b/utils/validators.go
@@ -109,6 +109,8 @@ func ValidFormatter(format string) (formatter.Formatter, error) {
 	switch format {
 	case "bash":
 		ret = formatter.Bash
+	case "bash-export":
+		ret = formatter.BashExport
 	case "dotenv":
 		ret = formatter.Dotenv
 	case "json":

--- a/utils/validators.go
+++ b/utils/validators.go
@@ -111,6 +111,10 @@ func ValidFormatter(format string) (formatter.Formatter, error) {
 		ret = formatter.Bash
 	case "bash-export":
 		ret = formatter.BashExport
+	case "bash-ifnotset":
+		ret = formatter.BashIfNotSet
+	case "bash-ifempty":
+		ret = formatter.BashIfEmpty
 	case "dotenv":
 		ret = formatter.Dotenv
 	case "json":

--- a/utils/validators_test.go
+++ b/utils/validators_test.go
@@ -202,7 +202,6 @@ func TestValidFormatter(t *testing.T) {
 	valid := map[string]formatter.Formatter{
 		"json":          formatter.JSON,
 		"bash":          formatter.Bash,
-		"bash-export":   formatter.BashExport,
 		"bash-ifnotset": formatter.BashIfNotSet,
 		"bash-ifempty":  formatter.BashIfEmpty,
 		"dotenv":        formatter.Dotenv,

--- a/utils/validators_test.go
+++ b/utils/validators_test.go
@@ -200,10 +200,13 @@ func TestValidEncryptionContext(t *testing.T) {
 func TestValidFormatter(t *testing.T) {
 
 	valid := map[string]formatter.Formatter{
-		"json":   formatter.JSON,
-		"bash":   formatter.Bash,
-		"dotenv": formatter.Dotenv,
-		"yaml":   formatter.YAML,
+		"json":          formatter.JSON,
+		"bash":          formatter.Bash,
+		"bash-export":   formatter.BashExport,
+		"bash-ifnotset": formatter.BashIfNotSet,
+		"bash-ifempty":  formatter.BashIfEmpty,
+		"dotenv":        formatter.Dotenv,
+		"yaml":          formatter.YAML,
 	}
 
 	for value, f := range valid {


### PR DESCRIPTION
### Problem

The default `bash` export format will set variables and overwrite them if they already exist.
We currently use this as part of our runtime container and there are cases where we want to override a secret that has been exported by `ejson-kms` whether for testing, debugging, or on local.

It is quite tedious to work around this and is easier if we can export the variables in more options.

### Solution

Additional formatting options than the regular `bash`:

- `bash-ifnotset` - `: ${VARIABLE='value'}`
  Will only set the variable if has not been previously set.

- `bash-ifempty` - `: ${VARIABLE:='value'}`
  Will only set the variable if it has not been previous set or equal to an empty string `''`